### PR TITLE
Add Evan's beam mapper

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 * [ ] I am involved in maintaining the linked resource, or I am adding this resource on the behalf of the maintainer(s) with their permission.
 * [ ] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change.
 * [ ] I have considered adding myself to the [Maintainers/Contributors](CONTRIBUTORS.txt) document.
-* [ ] My update to the list follows the format outlined in the [Contributing](CONTIBUTING.md) document:
+* [ ] My update to the list follows the format outlined in the [Contributing](CONTRIBUTING.md) document:
 
 ```markdown
 * [**Project Name**](https://example.com): A one sentence description of the item.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 * [ ] My update to the list follows the format outlined in the [Contributing](CONTIBUTING.md) document:
 
 ```markdown
-[**Project Name**](https://example.com): A one sentence description of the item.
+* [**Project Name**](https://example.com): A one sentence description of the item.
 ```
 
 ## Additional Information

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 ## Checklist
 
+Replace `[ ]` --> `[x]` to check off items.
+
 * [ ] I have followed the guidelines in our [Contributing](CONTRIBUTING.md) document.
 * [ ] I am involved in maintaining the linked resource, or I am adding this resource on the behalf of the maintainer(s) with their permission.
 * [ ] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,11 @@
 
 Replace `[ ]` --> `[x]` to check off items.
 
-* [ ] I have followed the guidelines in our [Contributing](CONTRIBUTING.md) document.
+* [ ] I have followed the guidelines in our Contributing document (see "Helpful resources", bottom right sidebar)
 * [ ] I am involved in maintaining the linked resource, or I am adding this resource on the behalf of the maintainer(s) with their permission.
-* [ ] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change.
-* [ ] I have considered adding myself to the [Maintainers/Contributors](CONTRIBUTORS.txt) document.
-* [ ] My update to the list follows the format outlined in the [Contributing](CONTRIBUTING.md) document:
+* [ ] I have checked to ensure there aren't other open Pull Requests for the same update/change.
+* [ ] I have considered adding myself to the Maintainers/Contributors (CONTRIBUTORS.txt) document.
+* [ ] My update to the list follows the format outlined in the Contributing document:
 
 ```markdown
 * [**Project Name**](https://example.com): A one sentence description of the item.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,9 @@
 * [ ] I have considered adding myself to the [Maintainers/Contributors](CONTRIBUTORS.txt) document.
 * [ ] My update to the list follows the format outlined in the [Contributing](CONTIBUTING.md) document:
 
-`[**Project Name**](https://example.com): A one sentence description of the item.`
+```markdown
+[**Project Name**](https://example.com): A one sentence description of the item.
+```
 
 ## Additional Information
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ The markdown for this looks like:
 [**Project Name**](https://example.com): A one sentence description of the item.
 ```
 
+List items shall be in alphabetical order, by the project name.
+
 ## Scope
 
 *To keep the content relevant and avoid becoming a dumping ground for ideas.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,12 @@ To make this resource as useful as possible and keep it easy to maintain, we set
 
 *To keep the list organized and readable.*
 
-[**Project Name**](https://example.com): A one sentence description of the item.
+* [**Project Name**](https://example.com): A one sentence description of the item.
 
 The markdown for this looks like:
 
 ```markdown
-[**Project Name**](https://example.com): A one sentence description of the item.
+* [**Project Name**](https://example.com): A one sentence description of the item.
 ```
 
 List items shall be in alphabetical order, by the project name.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ High-lift super-pressure, zero-pressure envelopes. e.g. SuperBIT, BLAST
 
 ### Ground Support Equipment
 
-* [**hotspot**](https://github.com/evanmayer/hotspot): A beam mapper for far-IR instruments; low-obscuration cable robot design carrying electronically chopped Hawkeye thermal sources.
+* [**hotspot**](https://evanmayer.github.io/hotspot): A beam mapper for far-IR instruments; low-obscuration cable robot design carrying electronically chopped Hawkeye thermal sources.
 
 ## Medium Balloons
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ High-lift super-pressure, zero-pressure envelopes. e.g. SuperBIT, BLAST
 
 ### Power Systems
 
+### Ground Support Equipment
+
+* [**hotspot**](https://github.com/evanmayer/hotspot): A beam mapper for far-IR instruments; low-obscuration cable robot design carrying electronically chopped Hawkeye thermal sources.
+
 ## Medium Balloons
 
 ## Small Balloons


### PR DESCRIPTION
## Checklist

* [x] I have followed the guidelines in our Contributing document (see "Helpful resources", bottom right sidebar)
* [x] I am involved in maintaining the linked resource, or I am adding this resource on the behalf of the maintainer(s) with their permission.
* [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
* [x] I have considered adding myself to the Maintainers/Contributors (CONTRIBUTORS.txt) document.
* [x] My update to the list follows the format outlined in the Contributing document:

* [**hotspot**](https://evanmayer.github.io/hotspot): A beam mapper for far-IR instruments; low-obscuration cable robot design carrying electronically chopped Hawkeye thermal sources.

## Additional Information

It's a beam mapper; virtually every millimeter/submm/IR experiment uses one at some point. Originally made for the TIME instrument, so it has some different design constraints than most mappers intended for lab use, but could easily be used for other experiments.